### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python zork.py"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Zork.py
 
+[![Run on Repl.it](https://repl.it/badge/github/iamjawa/zork-py)](https://repl.it/github/iamjawa/zork-py)
+
 Thank you for downloading a copy of Zork, The PY Edition!
 This Python Program is based loosely on the Storyline of Zork I, and is intended to run and function exactly like the original -
 the only difference being that this version is written with Python and can therefore be run and downloaded for free!


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@joshwood/zork-py).